### PR TITLE
Advanced Reports version 1.2.1

### DIFF
--- a/AdvancedReports.php
+++ b/AdvancedReports.php
@@ -559,6 +559,18 @@ class AdvancedReports extends \ExternalModules\AbstractExternalModule
 
 
 
+	// Returns the supplied string with any HTML entity encoded, with the exception of hyperlinks,
+	// and placeholders replaced with the corresponding values.
+	// This is used primarily for report descriptions.
+	function parseDescription( $str )
+	{
+		$str = str_replace( '$$PROJECT$$', intval( $this->getProjectId() ), $str );
+		$str = str_replace( '$$WEBROOT$$', APP_PATH_WEBROOT, $str );
+		return nl2br( $this->parseHTML( $str ) );
+	}
+
+
+
 	// Returns the supplied string with any HTML entity encoded, with the exception of hyperlinks.
 	// If the $forDownload parameter is true, hyperlink tags will be stripped instead.
 	function parseHTML( $str, $forDownload = false )
@@ -611,9 +623,9 @@ class AdvancedReports extends \ExternalModules\AbstractExternalModule
 		if ( $test )
 		{
 			$sql = str_replace( [ '$$DAG$$', '$$PROJECT$$', '$$ROLE$$' ], '0', $sql );
-			$sql = str_replace( '$$USER$$', "'a'", $sql );
+			$sql = str_replace( ['$$USER$$', '$$WEBROOT$$'], "'text'", $sql );
 			$sql = preg_replace( '/\$\$QINT\:[a-z0-9_]+\$\$/', '0', $sql );
-			$sql = preg_replace( '/\$\$QSTR\:[a-z0-9_]+\$\$/', "'a'", $sql );
+			$sql = preg_replace( '/\$\$QSTR\:[a-z0-9_]+\$\$/', "'text'", $sql );
 		}
 		else
 		{
@@ -626,6 +638,9 @@ class AdvancedReports extends \ExternalModules\AbstractExternalModule
 			$sql = str_replace( '$$ROLE$$', $userRole, $sql );
 			$sql = str_replace( '$$USER$$',
 			                    "'" . mysqli_real_escape_string( $conn, USERID ) . "'", $sql );
+			$sql = str_replace( '$$WEBROOT$$',
+			                    "'" . mysqli_real_escape_string( $conn, APP_PATH_WEBROOT ) . "'",
+			                    $sql );
 			$sql = preg_replace_callback( '/\$\$QINT\:([a-z0-9_]+)\$\$/',
 			                              function( $m )
 			                              {
@@ -723,6 +738,14 @@ class AdvancedReports extends \ExternalModules\AbstractExternalModule
 	function writeStyle()
 	{
 		$style = '
+			.mod-advrep-description a:link
+			{
+				text-decoration: underline dotted;
+			}
+			.mod-advrep-description a:hover
+			{
+				text-decoration: underline solid;
+			}
 			.mod-advrep-formtable
 			{
 				width: 97%;
@@ -821,6 +844,10 @@ class AdvancedReports extends \ExternalModules\AbstractExternalModule
 			.mod-advrep-datatable tr:nth-child(2n+1) td
 			{
 				background: #eee;
+			}
+			.mod-advrep-datatable a:link
+			{
+				text-decoration: underline solid;
 			}
 			.mod-advrep-gantt
 			{

--- a/README-SQL.md
+++ b/README-SQL.md
@@ -39,6 +39,7 @@ appropriate values before the query is run.
 * `$$ROLE$$` &ndash; the REDCap unique role ID of the user viewing the report
   * if the user is not in a role, *NULL* is used
 * `$$USER$$` &ndash; the username of the user viewing the report
+* `$$WEBROOT$$` &ndash; the REDCap version directory web path for use in URLs
 
 #### Query String Placeholders
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ as a Unix timestamp representing a UTC date/time.
 ### SQL report options
 
 * **Description** brief descriptive text to appear above the report
+  * HTML links (&lt;a&gt; tags) as well as the placeholders `$$PROJECT$$` (project ID) and
+    `$$WEBROOT$$` (REDCap version directory web path) can be used in the description.
 * **SQL Query** enter SELECT query here
 * **Result Type** choose how the SQL result is to be interpreted (normal or EAV)
 

--- a/sql_edit.php
+++ b/sql_edit.php
@@ -107,7 +107,9 @@ echo $reportData['sql_query'] ?? ''; ?></textarea>
      string (<i>NULL</i> if the value is missing)<br>
      <tt>$$ROLE$$</tt> &#8212; the REDCap unique role ID of the user viewing the report
      (<i>NULL</i> if the user is not in a role)<br>
-     <tt>$$USER$$</tt> &#8212; the username of the user viewing the report<br>&nbsp;
+     <tt>$$USER$$</tt> &#8212; the username of the user viewing the report<br>
+     <tt>$$WEBROOT$$</tt> &#8212; the REDCap version directory web path (<tt><?php
+echo htmlspecialchars( APP_PATH_WEBROOT ); ?></tt>), for use in URLs<br>&nbsp;
     </span>
    </td>
   </tr>

--- a/sql_view.php
+++ b/sql_view.php
@@ -229,7 +229,8 @@ $module->outputViewReportHeader( $reportConfig['label'], 'sql' );
 if ( isset( $reportData['sql_desc'] ) && $reportData['sql_desc'] != '' )
 {
 ?>
-<p><?php echo nl2br( $module->parseHTML( $reportData['sql_desc'] ) ); ?></p>
+<p class="mod-advrep-description"><?php
+	echo $module->parseDescription( $reportData['sql_desc'] ); ?></p>
 <?php
 }
 


### PR DESCRIPTION
This update to the Advanced Reports module incorporates the following changes:
* Links in report descriptions are now shown with a dotted underline.
* Links in tabular reports (currently just SQL reports) are now shown with a solid underline.
* A new placeholder `$$WEBROOT$$` has been added for SQL queries.
* The `$$PROJECT$$` and `$$WEBROOT$$` placeholders are now supported in report descriptions.