### PR TITLE
Advanced Reports version 1.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.phar
+/vendor/

--- a/AdvancedReports.php
+++ b/AdvancedReports.php
@@ -384,6 +384,10 @@ class AdvancedReports extends \ExternalModules\AbstractExternalModule
 			return;
 		}
 		$listIDs = json_decode( $listIDs, true );
+		if ( $listIDs === null )
+		{
+			return;
+		}
 		if ( ( $k = array_search( $reportID, $listIDs ) ) !== false )
 		{
 			unset( $listIDs[$k] );
@@ -472,7 +476,7 @@ class AdvancedReports extends \ExternalModules\AbstractExternalModule
 		if ( $config !== null )
 		{
 			$config = json_decode( $config, true );
-			if ( $configName !== null )
+			if ( $config !== null && $configName !== null )
 			{
 				if ( array_key_exists( $configName, $config ) )
 				{

--- a/README-SQL.md
+++ b/README-SQL.md
@@ -35,7 +35,12 @@ appropriate values before the query is run.
 
 * `$$DAG$$` &ndash; the REDCap unique DAG ID of the user viewing the report
   * if the user is not in a DAG, *NULL* is used
+* `$$DATATABLE$$` &ndash; the redcap_data table used by the current project
+  * use `$$DATATABLE:pid$$`, where `pid` is a project ID, to get the redcap_data table used by
+    that project
 * `$$LOGTABLE$$` &ndash; the redcap_log_event table used by the current project
+  * use `$$LOGTABLE:pid$$`, where `pid` is a project ID, to get the redcap_log_event table used by
+    that project
 * `$$PROJECT$$` &ndash; the current project ID
 * `$$ROLE$$` &ndash; the REDCap unique role ID of the user viewing the report
   * if the user is not in a role, *NULL* is used
@@ -43,7 +48,7 @@ appropriate values before the query is run.
 * `$$WEBROOT$$` &ndash; the REDCap version directory web path for use in URLs
 
 Placeholders which return strings will return the string appropriately escaped and encased in
-quotes, with the exception of the `$$LOGTABLE$$` placeholder.
+quotes, with the exception of the `$$DATATABLE$$` and `$$LOGTABLE$$` placeholders.
 
 #### Query String Placeholders
 

--- a/reports.php
+++ b/reports.php
@@ -13,7 +13,8 @@ if ( $module->getProjectSetting( 'report-list' ) !== null )
 	$settings = $module->getProjectSettings( $projectID );
 	foreach ( $settings as $settingKey => $settingValue )
 	{
-		if ( in_array( $settingKey, ['enabled', 'edit-if-design', 'edit-if-reports'] ) )
+		if ( in_array( $settingKey, ['enabled', 'edit-if-design', 'edit-if-reports'] ) ||
+		     substr( $settingKey, 0, 9 ) == 'reserved-' )
 		{
 			continue;
 		}

--- a/sql_edit.php
+++ b/sql_edit.php
@@ -111,7 +111,10 @@ echo $reportData['sql_query'] ?? ''; ?></textarea>
      You can use the following placeholder values in SQL queries:<br>
      <tt>$$DAG$$</tt> &#8212; the REDCap unique DAG ID of the user viewing the report
      (<i>NULL</i> if the user is not in a DAG)<br>
+     <tt>$$DATATABLE$$</tt> &#8212; the redcap_data table used by the current project<br>
+     <tt>$$DATATABLE:pid$$</tt> &#8212; the redcap_data table used by project <i>pid</i><br>
      <tt>$$LOGTABLE$$</tt> &#8212; the redcap_log_event table used by the current project<br>
+     <tt>$$LOGTABLE:pid$$</tt> &#8212; the redcap_log_event table used by project <i>pid</i><br>
      <tt>$$PROJECT$$</tt> &#8212; the current project ID<br>
      <tt>$$QINT:<i>name</i>$$</tt> &#8212; the value of the named query string parameter, as an
      integer (<i>NULL</i> if the value is missing or not an integer)<br>


### PR DESCRIPTION
* Added `$$DATATABLE$$` placeholder for SQL reports, to support multiple redcap_data tables.
* Added support for project IDs in `$$DATATABLE$$` and `$$LOGTABLE$$` placeholders, so the data/log tables for projects other than the current project can be referenced.
* Bug fix: Handle null data correctly so it will not result in an error.